### PR TITLE
Handle memoize edge-case; parse new episodes only; streamline Feed.ge…

### DIFF
--- a/crly/modules/handler.py
+++ b/crly/modules/handler.py
@@ -69,9 +69,6 @@ def _episode(ep_num="1", options={}):
     episodes.update({'episode': data})
     Store.update_show(data=episodes)
     print(f"[crly] Episode is now set to '{ep_num}' for {show}.")
-    return True
-
-  return False
 
 
 def _play(value=None, options={}):
@@ -126,7 +123,6 @@ def _next(value=None, options={}):
   # Store the new episode & episodes_data
   Store.update_show(data=episodes_data)
   print(f"[crly] Episode is now set to '{ep_num}' for {show}.")
-  return
 
 
 def _info(value=None, options={}):

--- a/crly/modules/utility.py
+++ b/crly/modules/utility.py
@@ -60,10 +60,14 @@ def _memoize(func):
   cache = dict()
 
   def memoized_fn(*args):
-    if args in cache:
-      return cache[args]
+    # Must remove lists and dicts in order to set as prop
+    sanitized = tuple(
+        [x for x in list(args) if type(x) is not dict and type(x) is not list])
+
+    if sanitized in cache:
+      return cache[sanitized]
     result = func(*args)
-    cache[args] = result
+    cache[sanitized] = result
     return result
 
   memoized_fn.__name__ = func.__name__
@@ -75,7 +79,7 @@ def _memoize(func):
 
 # Check if a show needs to be updated
 # -----------
-def _update_needed(show_data=[]):
+def _update_needed(show_data={}):
   if bool(show_data):
     current_time = datetime.now().timestamp()
     next_update = show_data.get("next_update")


### PR DESCRIPTION
…t_episodes

Utility.memoize had an issue where dicts or lists being passed as arguments
would raise an exception. I'm now sanitizing for both before storing the
arguments as a property in the cache object.

Feed.parse will only parse the newest episodes (as the old amount of episodes
are passed to the function, defaulting to 0).

Feed.get_episodes had some weird conditional statement used to determine if
old episodes could be found before. I'm now defaulting the variable to an
empty list if they could not be found -- which streamlines it a bit more and
cleans up the code.